### PR TITLE
Proposed changes inline

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,6 +1,6 @@
 # NAME
 
-Policy - Policies, Standards and Guidelines for CPAN Modules
+Policy - Policies, Standards and Guidelines for the world of Perl
 
 # VERSION
 
@@ -8,15 +8,13 @@ version 0.001000
 
 # ABOUT THIS NAMESPACE
 
-`Policy` is a namespace dedicated to documenting the human level of how code should be written,
-detailing current best practices and recommendations for scopes as narrow as individual authors,
-or guidelines as broad as all of CPAN.
+`Policy` is a namespace dedicated to documenting various current best practices and recommendations for scopes as narrow as individual authors, or guidelines as broad as all of CPAN.
 
 Existence of these policies are not necessarily gospel, but merely a canonicalization of human
 knowledge in a more consumable form that doesn't require active discussion.
 
-Members of a group may wish to force these standards on code they control, but there is nothing
-stopping an individual seeing these standards, and adopting them as their own anyway.
+Members of a group may wish to enforce these standards within code they control, but there is nothing
+stopping an individual consulting these standards, and adopting them as their own anyway.
 
 In fact, encouraging the adoption of such standards, especially in regards to `Toolchain` and `P5P`
 standards is highly encouraged.
@@ -66,8 +64,7 @@ At this time, there are three primary categories:
 
 # AUTHORSHIP OF NAMESPACES
 
-The exact recommended layout of any policy namespace, should in itself have a policy dictating it
-at some stage. However, in the interim, my personal suggestion is as follows:
+The exact recommended layout of any policy sub-namespace, should in itself (at some stage) have a policy encouraging a uniform layout. However, in the interim, my personal suggestion is as follows:
 
     Policy::<Category>::<Name>::<PolicyId>_<PolicyWordToken>
 
@@ -78,7 +75,7 @@ Where:
 - **`<PolicyId>`** is zero-padded 4-digit number such as `0001`
 - **`<PolicyWordToken>`** is a simple word expression intended to give some sort of identification, for example: `SimpleVersions`
 
-The purpose here of the `<PolicyId>_<PolicyWordToken>` is to enforce a simplified visual sort order
+The purpose here of the `<PolicyId>_<PolicyWordToken>` is to enforce a simplified visual and machine sort order
 that makes it clear the order in which the policies were added, to make it obvious which policies were
 added more recently.
 


### PR DESCRIPTION
The main highlights are
- Remove mention of "code" - the scope is waaaay broader than that, so much so that mentioning coding practices becomes a distraction
- Remove the "dictate layout for sub-spaces" - because I for one will never visually-version my own policies (as an example)
